### PR TITLE
Bug: Times purchased not displaying in product page #37

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "bangazon-client",
+  "name": "bangazon-client-bangazon-team-5-client-elizabeth",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/pages/products/[id]/index.js
+++ b/pages/products/[id]/index.js
@@ -39,7 +39,7 @@ export default function ProductDetail() {
         <Detail product={product} like={like} unlike={unlike}/>
         <Ratings
           refresh={refresh}
-          number_purchased={product.number_purchased}
+          number_purchased={product.number_sold}
           ratings={product.ratings}
           average_rating={product.average_rating}
           likes={product.likes}


### PR DESCRIPTION
**Ticket #37 **

Previously, the product details web app page did not display the "times purchased" for each product. After adjusting the codebase, the correct "time purchased" will display. 

**Changes**

- In the following module: pages/products/[id]/index.js, I updated the number_purchased to be equal to the correct number_sold parameter for product (line 42)

**Testing**
Description of how to test code...

- [ ] log into the web app and navigate to the products page
- [ ] click on a product to see its details
- [ ] you should see the number of times that product was purchased in the blue bar (most products will have zero)

**Related Tickets**
#30 