### PR TITLE
Complete an order

### DIFF
--- a/data/fetcher.js
+++ b/data/fetcher.js
@@ -20,9 +20,7 @@ const catchError = (err) => {
     window.location.href = "/login"
   }
   if (err.message === "404") {
-    console.log(
-      "404. There is no object at the requested endpoint matching the provided query"
-    )
+    throw Error(err.message)
   }
 }
 

--- a/data/fetcher.js
+++ b/data/fetcher.js
@@ -20,7 +20,9 @@ const catchError = (err) => {
     window.location.href = "/login"
   }
   if (err.message === "404") {
-    console.log("404. Requested resource does not exist")
+    console.log(
+      "404. There is no object at the requested endpoint matching the provided query"
+    )
   }
 }
 

--- a/data/fetcher.js
+++ b/data/fetcher.js
@@ -1,34 +1,33 @@
-const API_URL = 'http://localhost:8000'
+const API_URL = "http://localhost:8000"
 
 const checkError = (res) => {
   if (!res.ok) {
-    throw Error(res.status);
+    throw Error(res.status)
   }
   return res
 }
 
 const checkErrorJson = (res) => {
   if (res.status !== 200) {
-    throw Error(res.status);
+    throw Error(res.status)
   } else {
     return res.json()
   }
 }
 
-
 const catchError = (err) => {
-  if (err.message === '401') {
+  if (err.message === "401") {
     window.location.href = "/login"
   }
-  if (err.message === '404') {
-    throw Error(err.message);
+  if (err.message === "404") {
+    console.log("404. Requested resource does not exist")
   }
 }
 
-export const fetchWithResponse = (resource, options) => fetch(`${API_URL}/${resource}`, options)
-  .then(checkErrorJson)
-  .catch(catchError)
+export const fetchWithResponse = (resource, options) =>
+  fetch(`${API_URL}/${resource}`, options)
+    .then(checkErrorJson)
+    .catch(catchError)
 
-export const fetchWithoutResponse = (resource, options) => fetch(`${API_URL}/${resource}`, options)
-  .then(checkError)
-  .catch(catchError)
+export const fetchWithoutResponse = (resource, options) =>
+  fetch(`${API_URL}/${resource}`, options).then(checkError).catch(catchError)

--- a/data/orders.js
+++ b/data/orders.js
@@ -1,28 +1,28 @@
-import { fetchWithResponse } from './fetcher'
+import { fetchWithResponse } from "./fetcher"
 
 export function getCart() {
-  return fetchWithResponse('cart', {
+  return fetchWithResponse("cart", {
     headers: {
-      Authorization: `Token ${localStorage.getItem('token')}`
-    }
+      Authorization: `Token ${localStorage.getItem("token")}`,
+    },
   })
 }
 
 export function getOrders() {
-  return fetchWithResponse('orders', {
+  return fetchWithResponse("orders", {
     headers: {
-      Authorization: `Token ${localStorage.getItem('token')}`
-    }
+      Authorization: `Token ${localStorage.getItem("token")}`,
+    },
   })
 }
 
 export function completeCurrentOrder(orderId, paymentTypeId) {
-  return fetchWithResponse(`orders/${orderId}/complete`, {
-    method: 'PUT',
+  return fetchWithResponse(`orders/${orderId}`, {
+    method: "PUT",
     headers: {
-      Authorization: `Token ${localStorage.getItem('token')}`,
-      'Content-Type': 'application/json'
+      Authorization: `Token ${localStorage.getItem("token")}`,
+      "Content-Type": "application/json",
     },
-    body: JSON.stringify({paymentTypeId})
+    body: JSON.stringify({ payment_type: paymentTypeId }),
   })
 }

--- a/pages/cart.js
+++ b/pages/cart.js
@@ -1,39 +1,48 @@
-import { useRouter } from 'next/router'
-import { useEffect, useState } from 'react'
-import CardLayout from '../components/card-layout'
-import Layout from '../components/layout'
-import Navbar from '../components/navbar'
-import CartDetail from '../components/order/detail'
-import CompleteFormModal from '../components/order/form-modal'
-import { completeCurrentOrder, getCart } from '../data/orders'
-import { getPaymentTypes } from '../data/payment-types'
-import { removeProductFromOrder } from '../data/products'
+import { useRouter } from "next/router"
+import { useEffect, useState } from "react"
+import CardLayout from "../components/card-layout"
+import Layout from "../components/layout"
+import Navbar from "../components/navbar"
+import CartDetail from "../components/order/detail"
+import CompleteFormModal from "../components/order/form-modal"
+import { completeCurrentOrder, getCart } from "../data/orders"
+import { getPaymentTypes } from "../data/payment-types"
+import { removeProductFromOrder } from "../data/products"
+import { useAppContext } from "../context/state"
 
 export default function Cart() {
   const [cart, setCart] = useState({})
   const [paymentTypes, setPaymentTypes] = useState([])
   const [showCompleteForm, setShowCompleteForm] = useState(false)
   const router = useRouter()
+  const { profile } = useAppContext()
 
   const refresh = () => {
-    getCart().then(cartData => {
+    getCart().then((cartData) => {
       if (cartData) {
         setCart(cartData)
+      } else {
+        setCart({})
       }
     })
   }
 
   useEffect(() => {
     refresh()
-    getPaymentTypes().then(paymentData => {
-      if (paymentData) {
-        setPaymentTypes(paymentData)
-      }
-    })
-  }, [])
+    if (profile && profile.id) {
+      getPaymentTypes(profile.id).then((paymentData) => {
+        if (paymentData) {
+          setPaymentTypes(paymentData)
+        }
+      })
+    }
+  }, [profile])
 
   const completeOrder = (paymentTypeId) => {
-    completeCurrentOrder(cart.id, paymentTypeId).then(() => router.push('/my-orders'))
+    completeCurrentOrder(cart.id, paymentTypeId).then(() => {
+      setCart({})
+      router.push("/my-orders")
+    })
   }
 
   const removeProduct = (productId) => {
@@ -51,7 +60,12 @@ export default function Cart() {
       <CardLayout title="Your Current Order">
         <CartDetail cart={cart} removeProduct={removeProduct} />
         <>
-          <a className="card-footer-item" onClick={() => setShowCompleteForm(true)}>Complete Order</a>
+          <a
+            className="card-footer-item"
+            onClick={() => setShowCompleteForm(true)}
+          >
+            Complete Order
+          </a>
           <a className="card-footer-item">Delete Order</a>
         </>
       </CardLayout>

--- a/pages/cart.js
+++ b/pages/cart.js
@@ -17,14 +17,15 @@ export default function Cart() {
   const router = useRouter()
   const { profile } = useAppContext()
 
-  const refresh = () => {
-    getCart().then((cartData) => {
+  const refresh = async () => {
+    try {
+      const cartData = await getCart()
       if (cartData) {
         setCart(cartData)
-      } else {
-        setCart({})
       }
-    })
+    } catch (err) {
+      setCart({})
+    }
   }
 
   useEffect(() => {


### PR DESCRIPTION
Allows a user to add a payment type to the items in their cart and complete the order. Upon order completion, the cart is cleared and the user is redirected to `/my-orders`. The `/my-orders` page is currently non-functional and will be addressed in a separate PR.

Closes issue #4 

### Changes

1. data/orders.js: `/complete` was removed from the fetch URL to align with URL registered in the API. 

2. pages/cart.js: Added `profile.id` as an argument to getPaymentTypes and updated the useEffect dependencies to watch for changes to `profile`

3. pages/cart.js: Added try/catch block under the function definition for `refresh()` to catch 404 errors that are thrown when there is no open order. 

5. pages/cart.js: Updated completeOrder function to clear the cart with `setCart({})` after clicking complete order. 

### Testing

- [ ] (Optional) Re-initialize the database by running `./seed_data.sh` in the api repository's root directory
- [ ] Log into the app as Brenda and navigate to Cart
* Check the Orders table in db.sqlite3. You should see Brenda's order (pk=2) has a payment type of NULL.

- [ ] Click Complete Order. Select a payment method from the dropdown. Click Complete Order.
* You should be redirected to /my-orders. At this point, /my-orders is not functioning fully and will not have any data in the table.
* Check the Orders table in db.sqlite3. You should see Brenda's order (pk=2) now has an integer instead of NULL under payment type.

- [ ] Navigate back to Cart.

You should see an empty cart, and you should not get a pop-up error that prevents the page from loading.