### PR TITLE
Fix token and profile state management

### DIFF
--- a/components/navbar.js
+++ b/components/navbar.js
@@ -1,9 +1,9 @@
-import Link from 'next/link'
-import { useEffect, useState, useRef } from 'react'
-import { useAppContext } from '../context/state'
+import Link from "next/link"
+import { useEffect, useState, useRef } from "react"
+import { useAppContext } from "../context/state"
 
 export default function Navbar() {
-  const { token, profile } = useAppContext()
+  const { token, setToken, profile, setProfile } = useAppContext()
   const hamburger = useRef()
   const navbar = useRef()
   const [isLoggedIn, setIsLoggedIn] = useState(false)
@@ -15,8 +15,8 @@ export default function Navbar() {
   }, [token])
 
   const showMobileNavbar = () => {
-    hamburger.current.classList.toggle('is-active')
-    navbar.current.classList.toggle('is-active')
+    hamburger.current.classList.toggle("is-active")
+    navbar.current.classList.toggle("is-active")
   }
 
   const getLoggedInButtons = () => {
@@ -28,23 +28,39 @@ export default function Navbar() {
           </span>
         </a>
         <div className="navbar-dropdown is-right">
-          <Link href="/cart"><a className="navbar-item">Cart</a></Link>
-          <Link href="/my-orders"><a className="navbar-item">My Orders</a></Link>
-          <Link href="/payments"><a className="navbar-item">Payment Methods</a></Link>
-          <Link href="/profile"><a className="navbar-item">Profile</a></Link>
-          {
-            profile.store ?
-              <>
-                <Link href={`/stores/${profile.store.id}`}><a className="navbar-item">View Your Store</a></Link>
-                <Link href="/products/new"><a className="navbar-item">Add a new Product</a></Link>
-              </>
-              :
-              <Link href="/stores/new"><a className="navbar-item">Interested in selling?</a></Link>
-          }
+          <Link href="/cart">
+            <a className="navbar-item">Cart</a>
+          </Link>
+          <Link href="/my-orders">
+            <a className="navbar-item">My Orders</a>
+          </Link>
+          <Link href="/payments">
+            <a className="navbar-item">Payment Methods</a>
+          </Link>
+          <Link href="/profile">
+            <a className="navbar-item">Profile</a>
+          </Link>
+          {profile.store ? (
+            <>
+              <Link href={`/stores/${profile.store.id}`}>
+                <a className="navbar-item">View Your Store</a>
+              </Link>
+              <Link href="/products/new">
+                <a className="navbar-item">Add a new Product</a>
+              </Link>
+            </>
+          ) : (
+            <Link href="/stores/new">
+              <a className="navbar-item">Interested in selling?</a>
+            </Link>
+          )}
           <hr className="navbar-divider"></hr>
-          <a className="navbar-item" onClick={
-            () => {
-              localStorage.removeItem('token')
+          <a
+            className="navbar-item"
+            onClick={() => {
+              localStorage.removeItem("token")
+              setToken("")
+              setProfile({})
               setIsLoggedIn(false)
             }}
           >
@@ -65,9 +81,7 @@ export default function Navbar() {
             </a>
           </Link>
           <Link href="/login">
-            <a className="button is-light">
-              Log in
-            </a>
+            <a className="button is-light">Log in</a>
           </Link>
         </div>
       </div>
@@ -75,16 +89,30 @@ export default function Navbar() {
   }
 
   return (
-
-    <nav className="navbar mb-3 is-warning px-5 is-fixed-top is-top" role="navigation" aria-label="main navigation">
+    <nav
+      className="navbar mb-3 is-warning px-5 is-fixed-top is-top"
+      role="navigation"
+      aria-label="main navigation"
+    >
       <div className="navbar-brand">
+        <Link href="/">
+          <img
+            src="/images/logo.png"
+            alt="Logo"
+            style={{ width: "4rem", height: "4rem" }}
+            className="relative"
+          />
+        </Link>
 
-          <Link href="/">
-            <img src="/images/logo.png" alt="Logo" style={{ width:"4rem", height: "4rem"}} className="relative" />
-          </Link>
-
-
-        <a role="button" className="navbar-burger" aria-label="menu" aria-expanded="false" data-target="navbarBasicExample" ref={hamburger} onClick={showMobileNavbar}>
+        <a
+          role="button"
+          className="navbar-burger"
+          aria-label="menu"
+          aria-expanded="false"
+          data-target="navbarBasicExample"
+          ref={hamburger}
+          onClick={showMobileNavbar}
+        >
           <span aria-hidden="true"></span>
           <span aria-hidden="true"></span>
           <span aria-hidden="true"></span>
@@ -93,13 +121,15 @@ export default function Navbar() {
 
       <div className="navbar-menu" ref={navbar}>
         <div className="navbar-start">
-          <Link href="/products"><a className="navbar-item">Products</a></Link>
-          <Link href="/stores"><a className="navbar-item">Stores</a></Link>
+          <Link href="/products">
+            <a className="navbar-item">Products</a>
+          </Link>
+          <Link href="/stores">
+            <a className="navbar-item">Stores</a>
+          </Link>
         </div>
         <div className="navbar-end">
-          {
-            isLoggedIn ? getLoggedInButtons() : getLoggedOutButtons()
-          }
+          {isLoggedIn ? getLoggedInButtons() : getLoggedOutButtons()}
         </div>
       </div>
     </nav>

--- a/context/state.js
+++ b/context/state.js
@@ -24,6 +24,12 @@ export function AppWrapper({ children }) {
           }
         })
       }
+    } else {
+      if (!authRoutes.includes(router.pathname)) {
+        router.push("/login")
+      } else {
+        router.push(router.pathname)
+      }
     }
   }, [token, router.pathname])
 

--- a/context/state.js
+++ b/context/state.js
@@ -11,7 +11,7 @@ export function AppWrapper({ children }) {
 
   useEffect(() => {
     setToken(localStorage.getItem("token"))
-  }, [token])
+  }, [])
 
   useEffect(() => {
     const authRoutes = ["/login", "/register"]
@@ -25,7 +25,7 @@ export function AppWrapper({ children }) {
         })
       }
     }
-  }, [token])
+  }, [token, router.pathname])
 
   return (
     <AppContext.Provider value={{ profile, token, setToken, setProfile }}>


### PR DESCRIPTION
### Summary
This PR fixes issues with the `token` and `profile` state related to the currently logged in user. Previously, the token state would update whenever a new user logged in, but the profile state would not be set until there was a page refresh. Now, the token and profile state are set upon login, and they are cleared upon logout. 

Closes issue #46 

### Changes

**In context/state.js:**

* removed `token` from the useEffect that handles setToken. 
* added `router.pathname` to the dependency array in the useEffect that handles setProfile. This variable changes whenever the path is changed (i.e. from `/login` to `/`), and is needed to set the profile once the user successfully logs in and gets a token.
* added the else block of code below to handle re-routing to `/login` when there is no token stored in state, and restricting access of non-logged in users to only `/login` and `/register`. 

```javascript
    const authRoutes = ["/login", "/register"]
    if (token) {
      ...
    } else {
      if (!authRoutes.includes(router.pathname)) {
        router.push("/login")
      } else {
        router.push(router.pathname)
      }
    }
  }, [token, router.pathname])    

```

**In components/navbar.js**

* Added `setToken("")` and `setProfile({})` to the logout onClick function to clear the token and profile state and trigger the navigation to /login.

```javascript
          <a
            className="navbar-item"
            onClick={() => {
              localStorage.removeItem("token")
              setToken("")
              setProfile({})
              setIsLoggedIn(false)
            }}
          >
            Log out
          </a>
```

### Testing

- [ ] Open the Bangazon app. Log out if you are currently logged in.
- [ ] Open the React Dev Tools and select Context.Provider from the list of components. Expand the value prop and take note of the profile and token props. You will be watching these change in the next steps. While logged out, profile should be {} and token should be null.
* Note: there are two components called Context.Provider. Select the second one in the list, which comes just after AppWrapper. 

- [ ] Log in as any user. Watch the token and profile props update! 
- [ ] Navigate to cart and then payment methods. You should not need to refresh the pages to see the user's data.
- [ ] Log out and watch the props. Profile should be reset to {} and token should be reset to null. Because the token is now null, you should automatically be re-routed to /login.
- [ ] Navigate to /register. You should be able to access it.
- [ ] Try to navigate to any other app page (e.g. by manually typing localhost:3000/payments in the url bar). You should be sent back to /login.