### PR TITLE
Fixed bug where page refresh forces a logout

### DIFF
--- a/components/navbar.js
+++ b/components/navbar.js
@@ -1,4 +1,5 @@
 import Link from "next/link"
+import { useRouter } from "next/router"
 import { useEffect, useState, useRef } from "react"
 import { useAppContext } from "../context/state"
 
@@ -7,10 +8,13 @@ export default function Navbar() {
   const hamburger = useRef()
   const navbar = useRef()
   const [isLoggedIn, setIsLoggedIn] = useState(false)
+  const router = useRouter()
 
   useEffect(() => {
     if (token) {
       setIsLoggedIn(true)
+    } else {
+      setIsLoggedIn(false)
     }
   }, [token])
 
@@ -60,8 +64,7 @@ export default function Navbar() {
             onClick={() => {
               localStorage.removeItem("token")
               setToken("")
-              setProfile({})
-              setIsLoggedIn(false)
+              router.push("/login")
             }}
           >
             Log out

--- a/context/state.js
+++ b/context/state.js
@@ -15,21 +15,21 @@ export function AppWrapper({ children }) {
 
   useEffect(() => {
     const authRoutes = ["/login", "/register"]
+
+    const fetchData = async () => {
+      const profileData = await getUserProfile()
+      if (profileData) {
+        setProfile(profileData)
+      }
+    }
+
     if (token) {
       localStorage.setItem("token", token)
       if (!authRoutes.includes(router.pathname)) {
-        getUserProfile().then((profileData) => {
-          if (profileData) {
-            setProfile(profileData)
-          }
-        })
+        fetchData()
       }
     } else {
-      if (!authRoutes.includes(router.pathname)) {
-        router.push("/login")
-      } else {
-        router.push(router.pathname)
-      }
+      setProfile({})
     }
   }, [token, router.pathname])
 

--- a/context/state.js
+++ b/context/state.js
@@ -16,7 +16,7 @@ export function AppWrapper({ children }) {
   useEffect(() => {
     const authRoutes = ["/login", "/register"]
 
-    const fetchData = async () => {
+    const getAndSetProfile = async () => {
       const profileData = await getUserProfile()
       if (profileData) {
         setProfile(profileData)
@@ -26,7 +26,7 @@ export function AppWrapper({ children }) {
     if (token) {
       localStorage.setItem("token", token)
       if (!authRoutes.includes(router.pathname)) {
-        fetchData()
+        getAndSetProfile()
       }
     } else {
       setProfile({})


### PR DESCRIPTION
### Summary
Previously, I made changes to state.js that handled routing to /login if there was no token in state. To separate code responsibilities into components that made more sense, I moved the router.push("/login") to the onClick for Log Out in the Navbar. This amended logic flow resolved the issue where refreshing the page forced the user to log out. 

Closes issue #48 

### Changes Made
* in navbar.js, added`router.push("/login")` to the onClick function attached to the Logout button.
* in state.js, removed the `else` block that handled the `router.push("/login")` logic, and replaced it with `setProfile({})`. This change improves the "single responsibility principle" so that only state management (i.e. setting token and setting profile) is handled in the state.js module. 

### Testing
- [ ] authenticate into the app
- [ ] In the React Dev Tools under the AppWrapper component, verify that the token and profile was updated to the logged in user.
- [ ] refresh the page. The token and profile state should remain unchanged, and you should not be kicked out of the app.