### PR TITLE
Bug: Can't remove an item from the cart #29

### DIFF
--- a/components/order/detail.js
+++ b/components/order/detail.js
@@ -14,7 +14,7 @@ export default function CartDetail({ cart, removeProduct }) {
             <td>
               <span
                 className="icon is-clickable"
-                onClick={() => removeProduct(product.id)}
+                onClick={() => removeProduct(lineitem.product.id)}
               >
                 <i className="fas fa-trash"></i>
               </span>

--- a/data/products.js
+++ b/data/products.js
@@ -40,7 +40,7 @@ export function addProductToOrder(id) {
 }
 
 export function removeProductFromOrder(id) {
-  return fetchWithoutResponse(`products/${id}/remove-from-order`, {
+  return fetchWithoutResponse(`cart/${id}`, {
     method: 'DELETE',
     headers: {
       Authorization: `Token ${localStorage.getItem('token')}`

--- a/pages/cart.js
+++ b/pages/cart.js
@@ -48,11 +48,11 @@ export default function Cart() {
   }
 
   const removeProduct = (productId) => {
-    removeProductFromOrder(productId).then(refresh())
+    removeProductFromOrder(productId).then(() => {refresh()})
   }
 
   const deleteCurrentOrder = () => {
-    deleteOrder().then(refresh())
+    deleteOrder().then(() => {refresh()})
   }
 
   return (


### PR DESCRIPTION
Previously, the user was unable to delete singular items in their cart. After updating the codebase, the user now has that capability. 

## Changes
In data/products.js...

I updated the removeProductFromOrder function to have the correct url to the correct endpoint (line 43).

## Testing

- [ ] Reseed your api ./seed_data.sh
- [ ] login as a user that has items in their cart (brenda is a good option)
- [ ] navigate to the cart
- [ ] test deleting a single item from the cart. You should be able to delete one item at a time and the page should automatically refresh

## Related Tickets
#29 
#3 