### PR TITLE
Past orders not displaying

### DIFF
--- a/pages/my-orders.js
+++ b/pages/my-orders.js
@@ -1,40 +1,45 @@
-import { useEffect, useState } from 'react'
-import CardLayout from '../components/card-layout'
-import Layout from '../components/layout'
-import Navbar from '../components/navbar'
-import Table from '../components/table'
-import { getOrders } from '../data/orders'
+import { useEffect, useState } from "react";
+import CardLayout from "../components/card-layout";
+import Layout from "../components/layout";
+import Navbar from "../components/navbar";
+import Table from "../components/table";
+import { getOrders } from "../data/orders";
 
 export default function Orders() {
-  const [orders, setOrders] = useState([])
-  const headers = ['Order Date', 'Total', 'Payment Method']
+  const [orders, setOrders] = useState([]);
+  const headers = ["Order Date", "Total", "Payment Method"];
 
   useEffect(() => {
-    getOrders().then(ordersData => {
+    getOrders().then((ordersData) => {
       if (ordersData) {
-        setOrders(ordersData)
+        setOrders(ordersData);
       }
-    })
-  }, [])
+    });
+  }, []);
 
   return (
     <>
       <CardLayout title="Your Orders">
         <Table headers={headers}>
-          {
-            orders.map((order) => (
+          {orders.map((order) => {
+            const created_date = order.created_date;
+            const payment_type_info = order.payment_type_info;
+            const total_cost = order.lineitems.reduce((acc, lineitem) => {
+              return acc + lineitem.product.price;
+            }, 0);
+            return (
               <tr key={order.id}>
-                <td>{order.completed_on}</td>
-                <td>${order.total}</td>
-                <td>{order.payment_type?.obscured_num}</td>
+                <td>{created_date}</td>
+                <td>${total_cost.toFixed(2)}</td>
+                <td>{payment_type_info && payment_type_info.merchant_name}</td>
               </tr>
-            ))
-          }
+            );
+          })}
         </Table>
         <></>
       </CardLayout>
     </>
-  )
+  );
 }
 
 Orders.getLayout = function getLayout(page) {
@@ -43,5 +48,5 @@ Orders.getLayout = function getLayout(page) {
       <Navbar />
       <section className="container">{page}</section>
     </Layout>
-  )
-}
+  );
+};


### PR DESCRIPTION
This PR addresses ticket #2 when a user clicked to see their past orders the fields were displayed but empty.

The Orders component was not accessing the details of the order.  In order to add all the items together, I put in a mapping function in the JSX that iterates through the order and adds each item and displays the total cost.  For the payment method I only had to add a cell that extracted the payment info merchant name.  

In order to test it:

[] Sign in as a user with past orders
[] Go to the "My Orders" section
[] You should see the past orders the user has made with the date they were made, the total price and the merchant info for the payment used