### PR TITLE
Bugfix: A rating cannot be added to a product #60

### DIFF
--- a/components/rating/container.js
+++ b/components/rating/container.js
@@ -1,10 +1,10 @@
 import { RatingCard } from './card'
 import RatingForm from './form'
 
-export function RatingsContainer({ ratings, saveRating }) {
+export function RatingsContainer({ ratings, saveRating, product }) {
   return (
     <div className="tile is-parent is-12 is-vertical container">
-      <RatingForm saveRating={saveRating} />
+      <RatingForm saveRating={saveRating} product={product} />
       {
         ratings?.map((rating) => <RatingCard key={rating.id} rating={rating} />)
       }

--- a/components/rating/container.js
+++ b/components/rating/container.js
@@ -1,12 +1,12 @@
 import { RatingCard } from './card'
 import RatingForm from './form'
 
-export function RatingsContainer({ ratings, saveRating, product }) {
+export function RatingsContainer({ ratings, saveRating, product, refresh }) {
   return (
     <div className="tile is-parent is-12 is-vertical container">
-      <RatingForm saveRating={saveRating} product={product} />
+      <RatingForm saveRating={saveRating} product={product} refresh={refresh} />
       {
-        ratings?.map((rating) => <RatingCard key={rating.id} rating={rating} />)
+        ratings?.map((rating) => <RatingCard key={rating.id} rating={rating} refresh={refresh}/>)
       }
     </div>
   )

--- a/components/rating/detail.js
+++ b/components/rating/detail.js
@@ -24,7 +24,7 @@ export function Ratings({ product, average_rating, refresh, ratings = [], number
         numberPurchased={number_purchased}
         likesLength={likes.length}
       />
-      <RatingsContainer ratings={ratings} saveRating={saveRating} product={product} refresh={refresh}/>
+      <RatingsContainer ratings={ratings} saveRating={saveRating} product={product}/>
     </div>
   )
 }

--- a/components/rating/detail.js
+++ b/components/rating/detail.js
@@ -6,7 +6,7 @@ import { Header } from './header'
 export function Ratings({ product, average_rating, refresh, ratings = [], number_purchased, likes = [] }) {
   const [productId, setProductId] = useState(0)
   const saveRating = (productId, newRating) => {
-    rateProduct(productId, newRating).then(refresh)
+    rateProduct(productId, newRating).then(() => refresh())
 
   }
 
@@ -24,7 +24,7 @@ export function Ratings({ product, average_rating, refresh, ratings = [], number
         numberPurchased={number_purchased}
         likesLength={likes.length}
       />
-      <RatingsContainer ratings={ratings} saveRating={saveRating} product={product}/>
+      <RatingsContainer ratings={ratings} saveRating={saveRating} product={product} refresh={refresh}/>
     </div>
   )
 }

--- a/components/rating/detail.js
+++ b/components/rating/detail.js
@@ -3,9 +3,9 @@ import { rateProduct } from '../../data/products'
 import { RatingsContainer } from './container'
 import { Header } from './header'
 
-export function Ratings({ average_rating, refresh, ratings = [], number_purchased, likes = [] }) {
+export function Ratings({ product, average_rating, refresh, ratings = [], number_purchased, likes = [] }) {
   const [productId, setProductId] = useState(0)
-  const saveRating = (newRating) => {
+  const saveRating = (productId, newRating) => {
     rateProduct(productId, newRating).then(refresh)
 
   }
@@ -24,7 +24,7 @@ export function Ratings({ average_rating, refresh, ratings = [], number_purchase
         numberPurchased={number_purchased}
         likesLength={likes.length}
       />
-      <RatingsContainer ratings={ratings} saveRating={saveRating} />
+      <RatingsContainer ratings={ratings} saveRating={saveRating} product={product}/>
     </div>
   )
 }

--- a/components/rating/form.js
+++ b/components/rating/form.js
@@ -1,13 +1,13 @@
 import { Rating } from 'react-simple-star-rating'
 import { useState } from 'react'
 
-export default function RatingForm({ saveRating }) {
+export default function RatingForm({ saveRating, product }) {
   const [rating, setRating] = useState(0)
   const [comment, setComment] = useState("")
   
   const submitRating = () => {
     const outOf5 = rating/20
-    saveRating({
+    saveRating(product.id, {
       score: outOf5,
       review: comment
     })
@@ -19,7 +19,7 @@ export default function RatingForm({ saveRating }) {
     <div className="tile is-child ">
       <article className="media box">
         <figure className="media-left">
-          <Rating onClick={setRating} ratingValue={rating} />
+          <Rating onClick={setRating} ratingValue={rating} productId={product.id} />
         </figure>
         <div className="media-content">
           <div className="field">

--- a/components/rating/form.js
+++ b/components/rating/form.js
@@ -11,6 +11,8 @@ export default function RatingForm({ saveRating, product }) {
       score: outOf5,
       review: comment
     })
+    setComment("")
+    setRating(0)
   }
 
 

--- a/pages/products/[id]/index.js
+++ b/pages/products/[id]/index.js
@@ -43,6 +43,7 @@ export default function ProductDetail() {
           ratings={product.ratings}
           average_rating={product.average_rating}
           likes={product.likes}
+          product={product}
         />
       </div>
     </div>


### PR DESCRIPTION
This pull request outlines the changes that I made to the client to allow a user to add a rating on a product.

## Changes
In components/rating/form.js...
- I passed the product prop from pages/products/[id]/index.js down to components/rating/form.js
- I added product.id as the first argument in saveRating( )
- I added setComment("") and setRating(0) onto submitRating( ). This will reset the comment and rating when the "Post Rating" button is clicked

## Testing

### Setup
- [ ] Make sure you have the bugfix/rate-product as branch as your api
- [ ] Make sure your debugger is running
- [ ] Start your client
- [ ] Log in as any user

### Adding a Product Rating
- [ ] on the products page, click on any product
- [ ] Add a rating by clicking the stars and add a review. Then click the "Post Rating" button. 

### Expected Result
- [ ] After clicking the "Post Rating" button, the page should refresh and show the new avg rating for that product. This avg rating should be rounded to 1st decimal place. 
- [ ] Check your network tab to make sure the rate_product request got a 200 response
- [ ] Check your database to make sure the new rating is added to the bangazonapi_productrating table

## Related Ticket
Bugfix: A rating cannot be added to a product
[#60](https://github.com/NSS-Day-Cohort-68/bangazon-client-bangazon-team-5-client-elizabeth/issues/60)

## Things to Note: 
- The "# of reviews" on the product details page is displaying 0 and not the correct number of reviews.