### PR TITLE
Bugfix- add a product from new product form

### DIFF
--- a/pages/products/new.js
+++ b/pages/products/new.js
@@ -14,7 +14,7 @@ export default function NewProduct() {
       name: name.value,
       description: description.value,
       price: price.value,
-      categoryId: category.value,
+      category_id: category.value,
       location: location.value,
       quantity: quantity.value
     }


### PR DESCRIPTION
Update: I will include this bugfix in my next pull request but will leave this up as a draft in case anyone needs to post a product to a store in the meantime. 

This pull request is a tiny itsty-bitsy correction to the new product form. It was preparing a property called 'categoryId' when the server was expecting 'category_id'. 

To test, when logged an as a user with a store, navigate to the new product form and post a new product. You should see a 201 response code and the new product entered in the database.  