### PR TITLE
Seller's Store View

### DIFF
--- a/pages/stores/[id]/index.js
+++ b/pages/stores/[id]/index.js
@@ -1,12 +1,16 @@
-import { useRouter } from 'next/router'
-import { useEffect, useState } from 'react'
-import Layout from '../../../components/layout'
-import Navbar from '../../../components/navbar'
-import { ProductCard } from '../../../components/product/card'
-import Detail from '../../../components/store/detail'
-import { useAppContext } from '../../../context/state'
-import { deleteProduct } from '../../../data/products'
-import { favoriteStore, getStoreById, unfavoriteStore } from '../../../data/stores'
+import { useRouter } from "next/router"
+import { useEffect, useState } from "react"
+import Layout from "../../../components/layout"
+import Navbar from "../../../components/navbar"
+import { ProductCard } from "../../../components/product/card"
+import Detail from "../../../components/store/detail"
+import { useAppContext } from "../../../context/state"
+import { deleteProduct, getProducts } from "../../../data/products"
+import {
+  favoriteStore,
+  getStoreById,
+  unfavoriteStore,
+} from "../../../data/stores"
 
 export default function StoreDetail() {
   const { profile } = useAppContext()
@@ -14,21 +18,31 @@ export default function StoreDetail() {
   const { id } = router.query
   const [store, setStore] = useState({})
   const [isOwner, setIsOwner] = useState(false)
+  const [soldProducts, setSoldProducts] = useState([])
 
   useEffect(() => {
     if (id) {
       refresh()
     }
+    if (isOwner) {
+      const queryString = `store=${id}&number_sold=1`
+      getProducts(queryString).then((filteredProducts) => {
+        if (filteredProducts) {
+          setSoldProducts(filteredProducts)
+        }
+      })
+    }
     if (parseInt(id) === profile.store?.id) {
       setIsOwner(true)
     }
-  }, [id, profile])
+  }, [id, profile, isOwner])
 
-  const refresh = () => getStoreById(id).then(storeData => {
-    if (storeData) {
-      setStore(storeData)
-    }
-  })
+  const refresh = () =>
+    getStoreById(id).then((storeData) => {
+      if (storeData) {
+        setStore(storeData)
+      }
+    })
 
   const removeProduct = (productId) => {
     deleteProduct(productId).then(refresh)
@@ -44,24 +58,46 @@ export default function StoreDetail() {
 
   return (
     <>
-      <Detail store={store} isOwner={isOwner} favorite={favorite} unfavorite={unfavorite} />
+      <Detail
+        store={store}
+        isOwner={isOwner}
+        favorite={favorite}
+        unfavorite={unfavorite}
+      />
       <div className="columns is-multiline">
-        {
-          store.products?.map(product => (
-            <ProductCard
-              product={product}
-              key={product.id}
-              isOwner={isOwner}
-              removeProduct={removeProduct}
-            />
-          ))
-        }
-        {
-          store.products?.length === 0 ?
-            <p>There's no products yet</p>
-            :
-            <></>
-        }
+        {isOwner && (
+          <div className="column is-full">
+            <h2 className="title">Selling</h2>
+          </div>
+        )}
+        {store.products?.map((product) => (
+          <ProductCard
+            product={product}
+            key={product.id}
+            isOwner={isOwner}
+            removeProduct={removeProduct}
+          />
+        ))}
+        {store.products?.length === 0 ? <p>There's no products yet</p> : <></>}
+        {isOwner && (
+          <>
+            <div className="column is-full">
+              <h2 className="title">Sold Items</h2>
+            </div>
+            {soldProducts.length === 0 ? (
+              <p>You have not sold any products yet</p>
+            ) : (
+              soldProducts.map((product) => (
+                <ProductCard
+                  product={product}
+                  key={`sold-${product.id}`}
+                  isOwner={isOwner}
+                  removeProduct={removeProduct}
+                />
+              ))
+            )}
+          </>
+        )}
       </div>
     </>
   )


### PR DESCRIPTION
This page now displays all products offered by a store. If the store owner is viewing their own page, they will also see a section with the heading "Sold Items" that displays all products they have sold. 

Closes #13 

## Changes
* added useState for soldProducts
* if `isOwner` is true, get all products belonging to the store Id and whose number_sold is greater than or equal to 1. Set this list of products to the soldProducts useState.
* If `isOwner` is true, .map() through soldProducts to display each product card.

## Testing
- [ ] `git checkout` feature/13/seller-store-view on the api repo
- [ ] log in as Brenda. go to View Your Store from the dropdown menu
- [ ] You should see Selling and Sold Items section headings. The Selling section should have about 60 product cards. The Sold Items section should have 1 product card.
- [ ] log in as Steve. Navigate to stores/1 to see Brenda's store page. You should just see a list of about 60 products, and the Selling and Sold Items headings should not be present. 