### PR TITLE
Add recommendations, likes, and favorite stores to profile

### DIFF
--- a/pages/profile.js
+++ b/pages/profile.js
@@ -24,8 +24,8 @@ export default function Profile() {
         <div className="columns is-multiline">
           {profile.favorites?.map((favorite) => (
             <StoreCard
-              store={favorite}
-              key={favorite.id}
+              store={favorite.store}
+              key={favorite.store.id}
               width="is-one-third"
             />
           ))}

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -1,11 +1,11 @@
-import { useEffect } from 'react'
-import CardLayout from '../components/card-layout'
-import Layout from '../components/layout'
-import Navbar from '../components/navbar'
-import { ProductCard } from '../components/product/card'
-import { StoreCard } from '../components/store/card'
-import { useAppContext } from '../context/state'
-import { getUserProfile } from '../data/auth'
+import { useEffect } from "react"
+import CardLayout from "../components/card-layout"
+import Layout from "../components/layout"
+import Navbar from "../components/navbar"
+import { ProductCard } from "../components/product/card"
+import { StoreCard } from "../components/store/card"
+import { useAppContext } from "../context/state"
+import { getUserProfile } from "../data/auth"
 
 export default function Profile() {
   const { profile, setProfile } = useAppContext()
@@ -22,42 +22,50 @@ export default function Profile() {
     <>
       <CardLayout title="Favorite Stores" width="is-full">
         <div className="columns is-multiline">
-          {
-            profile.favorites?.map(favorite => (
-              <StoreCard store={favorite} key={favorite.id} width="is-one-third" />
-            ))
-          }
+          {profile.favorites?.map((favorite) => (
+            <StoreCard
+              store={favorite}
+              key={favorite.id}
+              width="is-one-third"
+            />
+          ))}
         </div>
         <></>
       </CardLayout>
       <CardLayout title="Products you've recommended" width="is-full">
         <div className="columns is-multiline">
-          {
-            profile.recommended_by?.map(recommendation => (
-              <ProductCard product={recommendation.product} key={recommendation.product.id} width="is-one-third" />
-            ))
-          }
+          {profile.recommender?.map((recommendation) => (
+            <ProductCard
+              product={recommendation.product}
+              key={recommendation.product.id}
+              width="is-one-third"
+            />
+          ))}
         </div>
         <></>
       </CardLayout>
       <CardLayout title="Products recommended to you" width="is-full">
         <div className="columns is-multiline">
-          {
-            profile.recommendations?.map(recommendation => (
-              <ProductCard product={recommendation.product} key={recommendation.product.id} width="is-one-third" />
-            ))
-          }
+          {profile.recommendations?.map((recommendation) => (
+            <ProductCard
+              product={recommendation.product}
+              key={recommendation.product.id}
+              width="is-one-third"
+            />
+          ))}
         </div>
         <></>
       </CardLayout>
 
       <CardLayout title="Products you've liked" width="is-full">
         <div className="columns is-multiline">
-          {
-            profile.likes?.map(product => (
-              <ProductCard product={product} key={product.id} width="is-one-third" />
-            ))
-          }
+          {profile.likes?.map((like) => (
+            <ProductCard
+              product={like.product}
+              key={like.product.id}
+              width="is-one-third"
+            />
+          ))}
         </div>
         <></>
       </CardLayout>


### PR DESCRIPTION
Updated the profile to .map through various attributes of the profile object to display the logged in user's recommendations, likes, and favorite stores. 

Resolves #8 

## Changes
* Fixed variable access when .mapping through favorites, recommended, recommendations, and likes on the profile view. 

## Testing
- [ ] log in as anyone
- [ ] recommend some products to a different user. like a few products. like a store.
- [ ] go to your profile. you should see products and stores that you just recommended and liked.
- [ ] log in as the person that you recommended products to. you should see those products in your recommendations list.